### PR TITLE
Update to pandoc version 2.11.2

### DIFF
--- a/src/Env.hs
+++ b/src/Env.hs
@@ -67,17 +67,17 @@ makeEnv (tag, name, rest) defs
     -- TODO: Might be useful to have this work with formatted tags, e.g. **Lemma**.
     toRawText :: Seq Inline -> Text
     toRawText S.Empty      = ""
-    toRawText (Str s:<|xs) = (T.pack s) `T.append` (toRawText xs)
+    toRawText (Str s:<|xs) = s `T.append` (toRawText xs)
     toRawText (Space:<|xs) = " " `T.append` (toRawText xs)
     toRawText (_    :<|xs) = toRawText xs
 
 -- Defines the first and last blocks of the TeX environment.
 makeDelimiters :: Tag -> Maybe String -> Inlines -> (Blocks, Block)
 makeDelimiters tagText nameText rest =
-    ( plain $ (rawInline "latex" $ "\\begin{" ++ tag ++ "}" ++ name) <> rest
+    ( plain $ (rawInline "latex" $ T.pack("\\begin{" ++ tag ++ "}" ++ name)) <> rest
       -- Closing block may be merged into the final body block, so keep it
       -- independent of other blocks for now.
-    , Plain [RawInline (Format "latex") ("\\end{" ++ tag ++ "}")]
+    , Plain [RawInline (Format "latex") (T.pack("\\end{" ++ tag ++ "}"))]
     )
   where
     tag  = getLatexEnvName tagText
@@ -129,7 +129,7 @@ splitTerm xs =
     closesParen = checkStr (T.isSuffixOf ")")
 
 checkStr :: (Text -> Bool) -> Inline -> Bool
-checkStr f (Str s) = f (T.pack s)
+checkStr f (Str s) = f s
 checkStr _ _       = False
 
 trimParens :: Seq Inline -> Seq Inline
@@ -159,7 +159,7 @@ dropPrefix :: Text -> Inline -> Inline
 dropPrefix = transformStr . T.stripPrefix
 
 transformStr :: (Text -> Maybe Text) -> Inline -> Inline
-transformStr f i@(Str s) = case f (T.pack s) of
-    Just s' -> Str $ T.unpack s'
+transformStr f i@(Str s) = case f s of
+    Just s' -> Str $ s'
     Nothing -> i
 transformStr _ i = i

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.26
+resolver: lts-16.9 
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -37,7 +37,14 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-# extra-deps: []
+extra-deps:
+- pandoc-2.10.1
+- pandoc-types-1.21
+- hslua-1.1.2
+- jira-wiki-markup-1.3.2
+- commonmark-0.1.0.1
+- commonmark-extensions-0.2.0.1
+- commonmark-pandoc-0.2.0.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.9 
+resolver: lts-16.23 
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -38,13 +38,17 @@ packages:
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- pandoc-2.10.1
-- pandoc-types-1.21
+- pandoc-2.11.2
+- pandoc-types-1.22
 - hslua-1.1.2
 - jira-wiki-markup-1.3.2
-- commonmark-0.1.0.1
-- commonmark-extensions-0.2.0.1
-- commonmark-pandoc-0.2.0.0
+- commonmark-0.1.1.2
+- commonmark-extensions-0.2.0.4
+- commonmark-pandoc-0.2.0.1
+- citeproc-0.2
+- rfc5051-0.2
+- skylighting-0.10.1
+- skylighting-core-0.10.1
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Similarly to #7, this pull request simply updates the dependencies to make pandoc-theorem compatible with the current version of pandoc and pandoc-types.